### PR TITLE
generateで作られるファイルを制限

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,20 @@ module WonderfulEditor2
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.generators do |g|
+      g.template_engine false
+      g.javascripts false
+      g.stylesheets false
+      g.helper false
+      g.test_framework :rspec,
+                       view_specs: false,
+                       routing_specs: false,
+                       helper_specs: false,
+                       controller_specs: false,
+                       request_specs: true
+    end
+
+    config.api_only = true
   end
 end


### PR DESCRIPTION
`application.rb`にgenerateで作られるファイルを制限する記述を追加