### PR TITLE
下書き機能の実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,5 @@
 class Article < ApplicationRecord
-  enum article_status: { draft: 0, published: 1 }
+  enum article_status: { draft: "draft", published: "published" }
 
   belongs_to :user
   has_many :comments, dependent: :destroy

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,6 @@
 class Article < ApplicationRecord
+  enum article_status: { draft: 0, published: 1 }
+
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy

--- a/db/migrate/20210118201149_create_articles.rb
+++ b/db/migrate/20210118201149_create_articles.rb
@@ -4,7 +4,6 @@ class CreateArticles < ActiveRecord::Migration[6.0]
       t.string :title
       t.text :body
       t.references :user, null: false, foreign_key: true
-      t.integer :article_status, null: false, default: 0
 
       t.timestamps
     end

--- a/db/migrate/20210118201149_create_articles.rb
+++ b/db/migrate/20210118201149_create_articles.rb
@@ -4,6 +4,7 @@ class CreateArticles < ActiveRecord::Migration[6.0]
       t.string :title
       t.text :body
       t.references :user, null: false, foreign_key: true
+      t.integer :article_status, null: false, default: 0
 
       t.timestamps
     end

--- a/db/migrate/20210123191213_add_status_to_articles.rb
+++ b/db/migrate/20210123191213_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :string, default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_18_201726) do
+ActiveRecord::Schema.define(version: 2021_01_23_191213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,9 +28,9 @@ ActiveRecord::Schema.define(version: 2021_01_18_201726) do
     t.string "title"
     t.text "body"
     t.bigint "user_id", null: false
-    t.integer "article_status", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_201726) do
     t.string "title"
     t.text "body"
     t.bigint "user_id", null: false
+    t.integer "article_status", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,5 +3,13 @@ FactoryBot.define do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
     association :user, factory: :user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,47 +1,55 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  let(:article) { build(:article) }
-  let!(:draft) { create_list(:article,4,article_status: "draft") }
-  let!(:published) { create_list(:article,3,article_status: "published") }
 
-  context "タイトルが指定されている時" do
-    it "記事が投稿できる" do
-      expect(article).to be_valid
+  describe "正常系" do
+    context "タイトルと内容が指定されている時" do
+      let(:article) { build(:article) }
+
+      it "記事が投稿できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "statusがdraftの時" do
+      let(:article) { build(:article, :draft) }
+
+      it "下書き記事が作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "statusがpublishedの時" do
+      let(:article) { build(:article, :published) }
+
+      it "公開記事が作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
     end
   end
 
-  context "タイトルが指定されていない時" do
-    it "記事が投稿できない" do
-      article.title = nil
+  describe "異常系" do
+    let(:article) { build(:article) }
 
-      expect(article).to be_invalid
-      expect(article.errors.details[:title][0][:error]).to eq :blank
+    context "タイトルが指定されていない時" do
+      it "記事が投稿できない" do
+        article.title = nil
+
+        expect(article).to be_invalid
+        expect(article.errors.details[:title][0][:error]).to eq :blank
+      end
     end
-  end
 
-  context "内容が指定されていない時" do
-    it "記事が投稿できない" do
-      article.body = nil
+    context "内容が指定されていない時" do
+      it "記事が投稿できない" do
+        article.body = nil
 
-      expect(article).to be_invalid
-      expect(article.errors.details[:body][0][:error]).to eq :blank
-    end
-  end
-
-  context "下書き記事だけ取得しようとした時" do
-    it "取得できる" do
-      search_result_count = Article.where(article_status: "draft").count
-
-      expect(search_result).to eq 4
-    end
-  end
-
-  context "公開記事だけ取得しようとした時" do
-    it "取得できる" do
-      search_result_count = Article.where(article_status: "published").count
-
-      expect(search_result).to eq 3
+        expect(article).to be_invalid
+        expect(article.errors.details[:body][0][:error]).to eq :blank
+      end
     end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-
   describe "正常系" do
     context "タイトルと内容が指定されている時" do
       let(:article) { build(:article) }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe Article, type: :model do
   let(:article) { build(:article) }
+  let!(:draft) { create_list(:article,4,article_status: "draft") }
+  let!(:published) { create_list(:article,3,article_status: "published") }
 
   context "タイトルが指定されている時" do
     it "記事が投稿できる" do
@@ -24,6 +26,22 @@ RSpec.describe Article, type: :model do
 
       expect(article).to be_invalid
       expect(article.errors.details[:body][0][:error]).to eq :blank
+    end
+  end
+
+  context "下書き記事だけ取得しようとした時" do
+    it "取得できる" do
+      search_result_count = Article.where(article_status: "draft").count
+
+      expect(search_result).to eq 4
+    end
+  end
+
+  context "公開記事だけ取得しようとした時" do
+    it "取得できる" do
+      search_result_count = Article.where(article_status: "published").count
+
+      expect(search_result).to eq 3
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -5287,8 +5287,8 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-forge@^0.10.0:
-  version "0.10.0"
+node-forge@0.9.0:
+  version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
   integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
 


### PR DESCRIPTION
# 概要
- Article modelにenumの`status`カラムを追加。draft(下書き)とpublished(公開記事)の２種類の状態を持たせられるようにした。
- 下書き記事と公開記事についてのテストを実装